### PR TITLE
wwiv5_upgrade.bat v2.5

### DIFF
--- a/wintools/wwiv5_upgrade.bat
+++ b/wintools/wwiv5_upgrade.bat
@@ -1,90 +1,218 @@
-@Echo Off
+@ECHO OFF
 
+:SWITCHES
+IF [%1]==[] GOTO START
+IF [%1]==[?] GOTO USAGE
+IF [%1]==[-?] GOTO USAGE
+IF [%1]==[/?] GOTO USAGE
+
+:LAUNCH 
+SET olddir=%CD%
+
+:GETADMIN
 :: BatchGotAdmin
 :-------------------------------------
 REM  --> Check for permissions
 >nul 2>&1 "%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config\system"
 
 REM --> If error flag set, we do not have admin.
-if '%errorlevel%' NEQ '0' (
-    echo Requesting administrative privileges...
-    goto UACPrompt
-) else ( goto gotAdmin )
+IF '%errorlevel%' NEQ '0' (
+    ECHO Requesting administrative privileges...
+    GOTO UACPrompt
+) ELSE ( goto gotAdmin )
 
 :UACPrompt
-    echo Set UAC = CreateObject^("Shell.Application"^) > "%temp%\getadmin.vbs"
-    echo UAC.ShellExecute "%~s0", "%1", "", "runas", 1 >> "%temp%\getadmin.vbs"
+    ECHO Set UAC = CreateObject^("Shell.Application"^) > "%temp%\getadmin.vbs"
+    ECHO UAC.ShellExecute "%~s0", "%1", "", "runas", 1 >> "%temp%\getadmin.vbs"
 
     "%temp%\getadmin.vbs"
-    exit /B
+    EXIT /B
 
 :gotAdmin
-    if exist "%temp%\getadmin.vbs" ( del "%temp%\getadmin.vbs" )
+    IF exist "%temp%\getadmin.vbs" ( DEL "%temp%\getadmin.vbs" )
     pushd "%CD%"
     CD /D "%~dp0"
 :--------------------------------------
 
-@Echo OFF
+:START
+@ECHO OFF
+REM CREATE UNIQUE FILE NAME FOR BACKUP
+SET local 
+SET year=%DATE:~-4,4% 
+SET month=%DATE:~-7,2% 
+SET day=%DATE:~-10,2% 
+SET hour=%TIME:~0,2% 
+REM REMOVE HOUR LEADING ZEROS 
+IF '%hour:~0,1%' == ' ' set hour=0%hour:~1,1% 
+SET minute=%time:~3,2% 
+SET seconds=%time:~6,2% 
+SET timestamp=%year%%month%%day%%hour%%minute%%seconds%
+REM TRIM OUT SPACES
+SET timestamp=%timestamp: =%
 
 REM This requires you have WGET You need the Binaries
 REM and the dependencies which can be found here:
 REM http://gnuwin32.sourceforge.net/packages/wget.htm
 
-REM This requires you have 7ZIP which can be found here:
+REM This requires you have 7-ZIP which can be found here:
 REM http://www.7-zip.org/download.html
 REM or modify to use your favorite compression utility.
 
+:CHECKAPPS
+REM CONFIRM WGET EXISTS
+CLS
 
-IF [%1]==[] GOTO USAGE
-IF [%1]==[?] GOTO USAGE
-IF [%1]==[-?] GOTO USAGE
-IF [%1]==[/?] GOTO USAGE
+:WGET64
+IF EXIST "%PROGRAMFILES(x86)%\GnuWin32\bin\wget.exe" (GOTO CHECK7Z) ELSE (GOTO WGET32)
 
-:BEGIN
-set local
-REM Preparing Timestamp Information
-set year=%date:~10,4%
-set month=%date:~4,2%
-set day=%date:~7,2%
-set hour=%time:~0,2%
-REM Replace leading space with zero
-if “%hour:~0,1%” ==” ” set hour=0%hour:~1,1%
-set minute=%time:~3,2%
-set seconds=%time:~6,2%
-set timestamp=%year%%month%%day%%hour%%minute%%seconds%
-set backup_file=%userprofile%\documents\%timestamp%_wwiv.zip
-
-REM BAckup the current running version 
-c:
-cd \
-
-7z a -r %backup_file% c:\wwiv\*.*
-
-REM GET the New Build and upgrade the install
-c:
-cd %userprofile%\downloads\
-c:\tools\wget http://build.wwivbbs.org/job/WWIV/label=windows/%1/artifact/wwiv-build-win-%1.zip
-7z e -oc:\wwiv -y wwiv-build-win-%1.zip *.exe
-7z e -oc:\wwiv -y wwiv-build-win-%1.zip *.dll
-7z e -o%SystemRoot%\system32 -y wwiv-build-win-%1.zip *.dll
+:WGET32
+IF EXIST "%PROGRAMFILES%\GnuWin32\bin\wget.exe" (
+GOTO CHECK7Z
+) ELSE (
+ECHO THIS PROGRAM REQUIRES WGET
+ECHO http://gnuwin32.sourceforge.net/packages/wget.htm
+ECHO.
 GOTO DONE
+)
+
+:CHECK7Z
+IF EXIST "%PROGRAMFILES%\7-Zip\7z.exe" (
+GOTO CHECKOS
+) ELSE (
+ECHO THIS PROGRAM REQUIRES Z-Zip
+ECHO http://www.7-zip.org/download.html
+ECHO.
+GOTO DONE
+)
+
+:CHECKOS
+REM Check 64bit or 32bit OS
+IF EXIST "%PROGRAMFILES(X86)%" (GOTO 64BIT) ELSE (GOTO 32BIT)
+
+:64BIT
+SET wgetpath=%PROGRAMFILES(x86)%
+GOTO INPUTS
+
+:32BIT
+SET wgetpath=%PROGRAMFILES%
+GOTO INPUTS
+
+:INPUTS
+CLS
+ECHO.
+ECHO *** MAKE SURE WWIV AND TELNET SERVER ARE CLOSED BEFORE PROCEEDING ***
+ECHO.
+ECHO.
+ECHO ENTER BUILD NUMBER FOR UPDATE OR PRESS ENTER FOR LATEST BUILD CAPTURE
+ECHO.
+SET /p build=Enter Build Number: 
+
+IF %build% EQU '' (
+SET autoget=1
+GOTO TOOL
+) ELSE (
+SET autoget=0
+GOTO BACKUPWWIV
+)
+
+:BACKUPWWIV
+REM BACKUP WWIV
+SET backup_file1=%USERPROFILE%\documents\%timestamp%_wwiv.zip
+CD "%ProgramFiles%\7-Zip\"
+7z.exe a -r -y %backup_file1% C:\wwiv\*.*
+GOTO FETCHWWIV
+
+:FETCHWWIV
+REM FETCH NEW WWIV UPDATE
+CD %USERPROFILE%\downloads\
+
+IF %autoget% EQU [1] (
+REM FETCH LATEST BUILD AND PAtCH WWIV
+"%WGETPATH%"\GnuWin32\bin\wget.exe -r -np -nd --accept zip,ZIP --reject=htm,html,php,asp,txt,md --timestamping -e robots=off http://build.wwivbbs.org/job/wwiv/lastSuccessfulBuild/label=windows/artifact/
+DEL /Q archive.zip
+DIR /B wwiv-build-win*.zip > build_file.txt
+FOR /f "tokens=* delims= " %%a IN (build_file.txt) DO (
+SET FILENAME1=%%a
+)
+TIMEOUT /T 1
+"%PROGRAMFILES%\7-Zip\7z.exe" e -oc:\wwiv -y %FILENAME1% *.exe
+TIMEOUT /T 1
+"%PROGRAMFILES%\7-Zip\7z.exe" e -oc:\wwiv -y %FILENAME1% *.dll
+TIMEOUT /T 1
+"%PROGRAMFILES%\7-Zip\7z.exe" e -o%SYSTEMROOT%\system32 -y %FILENAME1% *.dll
+DEL /Q build_file.txt
+) ELSE (
+SET build_file=http://build.wwivbbs.org/job/WWIV/%build%/label=windows/artifact/wwiv-build-win-%build%.zip
+"%wgetpath%"\GnuWin32\bin\wget.exe %build_file%
+REM EXTRACT FILES FOR UPDATE
+TIMEOUT /T 1
+"%PROGRAMFILES%\7-Zip\7z.exe" e -oc:\wwiv -y wwiv-build-win-%build%.zip *.exe
+TIMEOUT /T 1
+"%PROGRAMFILES%\7-Zip\7z.exe" e -oc:\wwiv -y wwiv-build-win-%build%.zip *.dll
+TIMEOUT /T 1
+"%PROGRAMFILES%\7-Zip\7z.exe" e -o%SystemRoot%\system32 -y wwiv-build-win-%build%.zip *.dll
+)
+GOTO RUNWWIV
 
 :USAGE
+CLS
 ECHO How to Use WWIV 5.0 build to build wwiv5_upgrade.bat
 ECHO.
-ECHO     SYNTAX: wwiv5_upgrade.bat ####
-ECHO         ### is a build number
+ECHO     SYNTAX: wwiv5_upgrade.bat
 ECHO.
 ECHO     Paths and files names are based on your environment
-ECHO     Requires WGET and 7Zip. Links in the Comments.
+ECHO     Requires WGET and 7-Zip. Links in the Comments.
 ECHO.
 ECHO     Backup will be placed here: 
-ECHO         %userprofile%\documents\timestamp_wwiv.zip
+ECHO         %USERPROFILE%\documents\timestamp_wwiv.zip
 ECHO     New Build is expects to be found here: 
-ECHO         http://build.wwivbbs.org/job/WWIV/label=windows
-ECHO              /####/artifact/wwiv-build-win-####.zip
+ECHO         http://build.wwivbbs.org/job/WWIV/####/label=windows
+ECHO              /artifact/wwiv-build-win-####.zip
 ECHO.
+GOTO DONE
+
+:RUNWWIV
+CLS
+ECHO.
+ECHO PLEASE CHOOSE AN OPTION
+ECHO.
+ECHO 1) Launch WWIV with WWIVNet
+ECHO 2) Launch WWIV Only
+ECHO 3) Launch Nothing and Exit
+ECHO.
+set /p run_wwiv="Select Option: "
+ECHO.
+IF [%run_wwiv%] EQU [1] GOTO LAUNCHWWIVNET IF NOT GOTO RUNWWIV
+IF [%run_wwiv%] EQU [2] GOTO LAUNCHWWIV IF NOT GOTO RUNWWIV
+IF [%run_wwiv%] EQU [3] GOTO CHANGES IF NOT GOTO RUNWWIV
+
+:LAUNCHWWIVNET
+CD \wwiv
+START /MIN C:\wwiv\WWIV5TelnetServer.exe
+TIMEOUT /T 2
+START C:\wwiv\bbs.exe -N1 -M
+TIMEOUT /T 2
+START /MIN C:\wwiv\binkp.cmd
+GOTO CHANGES
+
+:LAUNCHWWIV
+CD \wwiv
+START /MIN C:\wwiv\WWIV5TelnetServer.exe
+TIMEOUT /T 2
+C:\wwiv\bbs.exe -N1 -M
+GOTO CHANGES
+
+:CHANGES
+START http://build.wwivbbs.org/job/wwiv/lastSuccessfulBuild/label=windows/changes
+GOTO DONE
+
+:ABORT
+ECHO.
+ECHO UPDATE ABORTED BY USER
 GOTO DONE
 
 :DONE
-pause
+cd "%olddir%"
+ECHO.
+TIMEOUT /T 30
+EXIT /B


### PR DESCRIPTION
This version will auto fetch latest build if no build number is entered at the prompt.  Removed WinRAR option for a global standard use of 7-Zip. Added a few pauses (1-2 second timeouts) to stabilize floating points to ensure system readiness.
